### PR TITLE
components rearrangment

### DIFF
--- a/src/components/LandingPage/Footer.js
+++ b/src/components/LandingPage/Footer.js
@@ -68,14 +68,6 @@ const Footer = () => {
                         Git Hash
                     </a>
                 </FooterItem>
-                <FooterDivider></FooterDivider>
-                <FooterItem>
-                    <Link to="/brand-assets">Brand Assets</Link>
-                </FooterItem>
-                <FooterDivider></FooterDivider>
-                <FooterItem>
-                    <Link to="/codebase">Codebase</Link>
-                </FooterItem>
             </LeftFooter>
             <RighFooter>
                 <LogoWrapper>

--- a/src/components/LandingPage/Header.tsx
+++ b/src/components/LandingPage/Header.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import styled from 'styled-components';
 import links from '../../links'
 
@@ -49,7 +49,7 @@ const LogoContainer = styled.div`
     cursor: pointer;
 `;
 
-const MenuItem = styled.a`
+const MenuItem = styled(Link)`
     font-family: Source Sans Pro;
     font-style: normal;
     font-weight: 600;
@@ -90,8 +90,8 @@ const MobileNav = styled.div`
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 180px;
     border-bottom: 1px solid var(--footer-divider);
+    padding-bottom: 12px;
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.05);
     ${props => {
         if(props.active) {
@@ -103,7 +103,7 @@ const MobileNav = styled.div`
     z-index: 1;
 `;
 
-const MobileMenuItem = styled.a`
+const MobileMenuItem = styled(Link)`
     color: var(--dark-text);
     font-size: 16px;
     font-weight: 600;
@@ -141,36 +141,36 @@ const NavBar = ({}) => {
         }
     }
 
+    const handleLogoClicked = (): void => {
+        if(active === true){
+            setActive(false);
+        }
+    }
+
     return (
         <NavWrapper>
             <LeftNav>
                 <NavItem route="/">
-                    <DXdaoLogo src="Dxdao_Landing.svg"/>
+                    <DXdaoLogo src="Dxdao_Landing.svg" onClick={handleLogoClicked}/>
                 </NavItem>
             </LeftNav>
             <RightNav>
-                <MenuItem href={links.header_governance} target="_blank">
-                    Governance
+                <MenuItem to={links.landing_codebase} >
+                    Codebase
                 </MenuItem>
-                <MenuItem href={links.header_chat} target="_blank">
-                    Chat
-                </MenuItem>
-                <MenuItem href={links.header_forum} target="_blank">
-                    Forum
+                <MenuItem to={links.landing_brand}>
+                    Brand Assets
                 </MenuItem>
                 <MobileMenu onClick={toggleMenu}>
                     <img src="menu-burger.svg" alt="Menu" />
                 </MobileMenu>
             </RightNav>
             <MobileNav active={active}>
-                <MobileMenuItem href="https://alchemy.daostack.io/dao/0x519b70055af55a007110b4ff99b0ea33071c720a" target="_blank">
-                    Governance
+                <MobileMenuItem to={links.landing_codebase} onClick={toggleMenu}>
+                    Codebase
                 </MobileMenuItem>
-                <MobileMenuItem href="https://keybase.io/team/dx_dao" target="_blank">
-                    Chat
-                </MobileMenuItem>
-                <MobileMenuItem href="https://daotalk.org/c/daos/dx-dao/15" target="_blank">
-                    Forum
+                <MobileMenuItem to={links.landing_brand} onClick={toggleMenu}>
+                    Brand Assets
                 </MobileMenuItem>
             </MobileNav>
         </NavWrapper>

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -322,7 +322,7 @@ const JoinActionWrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-top: 32px;
+    margin-top: 24px;
 `;
 
 const JoinAction = styled.a`
@@ -397,6 +397,50 @@ const LandingPage = () => {
                     Owned and operated by the community, the DXdao has the
                     potential to significantly scale its membership.
                 </Description>
+                <JoinActionWrapper>
+                    <JoinAction
+                        href={links.landing_create_proposal}
+                        target="_blank"
+                    >
+                        <JoinActionText>Create a proposal</JoinActionText>
+                        <JoinActionArrow src="RightArrow.svg" />
+                    </JoinAction>
+                    <JoinAction
+                        href={links.landing_start_forum_discussion}
+                        target="_blank"
+                    >
+                        <JoinActionText>
+                            Start a forum discussion
+                        </JoinActionText>
+                        <JoinActionArrow src="RightArrow.svg" />
+                    </JoinAction>
+                    <JoinAction
+                        href={links.landing_community_chat}
+                        target="_blank"
+                    >
+                        <JoinActionText>Community chat</JoinActionText>
+                        <JoinActionArrow src="RightArrow.svg" />
+                    </JoinAction>
+                    <JoinAction
+                        href={links.landing_developer_chat}
+                        target="_blank"
+                    >
+                        <JoinActionText>Developer chat</JoinActionText>
+                        <JoinActionArrow src="RightArrow.svg" />
+                    </JoinAction>
+                </JoinActionWrapper>
+            </BannerSection>
+            <DXDSection>
+                <DXDLogo src="DXD.svg" />
+                <Message>DXD powers the Decentralised Ecosystem</Message>
+                <Description margin="12px">
+                    The DXD token is DXdao´s native token. DXD token holders
+                    have an economic claim to the DXdao´s revenue. It also
+                    grants its owners future access to a suite of services and
+                    premium features in decentralised applications, such as
+                    glasless transactions, feeless anonymizing of assets,
+                    reduced trading fees on DEX protocols and more.
+                </Description>
                 <ButtonRow>
                     <BlueButton route="/exchange">Invest</BlueButton>
                     <NormalButton route="/faq">FAQ</NormalButton>
@@ -411,18 +455,6 @@ const LandingPage = () => {
                         Whitepaper
                     </Button>
                 </ButtonRow>
-            </BannerSection>
-            <DXDSection>
-                <DXDLogo src="DXD.svg" />
-                <Message>DXD powers the Decentralised Ecosystem</Message>
-                <Description margin="12px">
-                    The DXD token is DXdao´s native token. DXD token holders
-                    have an economic claim to the DXdao´s revenue. It also
-                    grants its owners future access to a suite of services and
-                    premium features in decentralised applications, such as
-                    glasless transactions, feeless anonymizing of assets,
-                    reduced trading fees on DEX protocols and more.
-                </Description>
             </DXDSection>
             <ProductSection>
                 <TagLine>Our collectively owned products</TagLine>
@@ -532,41 +564,6 @@ const LandingPage = () => {
                     </AboutPanel>
                 </AboutPanelWrapper>
             </AboutUsSection>
-            <JoinSection>
-                <Message>Join now</Message>
-                <JoinActionWrapper>
-                    <JoinAction
-                        href={links.landing_create_proposal}
-                        target="_blank"
-                    >
-                        <JoinActionText>Create a proposal</JoinActionText>
-                        <JoinActionArrow src="RightArrow.svg" />
-                    </JoinAction>
-                    <JoinAction
-                        href={links.landing_start_forum_discussion}
-                        target="_blank"
-                    >
-                        <JoinActionText>
-                            Start a forum discussion
-                        </JoinActionText>
-                        <JoinActionArrow src="RightArrow.svg" />
-                    </JoinAction>
-                    <JoinAction
-                        href={links.landing_community_chat}
-                        target="_blank"
-                    >
-                        <JoinActionText>Community chat</JoinActionText>
-                        <JoinActionArrow src="RightArrow.svg" />
-                    </JoinAction>
-                    <JoinAction
-                        href={links.landing_developer_chat}
-                        target="_blank"
-                    >
-                        <JoinActionText>Developer chat</JoinActionText>
-                        <JoinActionArrow src="RightArrow.svg" />
-                    </JoinAction>
-                </JoinActionWrapper>
-            </JoinSection>
         </LandingPageWrapper>
     );
 };

--- a/src/links.js
+++ b/src/links.js
@@ -6,6 +6,10 @@ landing_invest : "/exchange",
 
 landing_faq : "/faq",
 
+landing_codebase : "/codebase",
+
+landing_brand : "/brand-assets",
+
 landing_whitepaper : 'https://github.com/gnosis/dx-daostack/blob/master/dxdao_whitepaper_v1.pdf',
 
 landing_mixeth : "https://daotalk.org/t/mix-eth-seeking-feedback-on-proposal/1183",


### PR DESCRIPTION
- replaced current footer (Governance, Chat, Forum) with Codebase and Brand Asset Pages
- move button row below the DXD component
- move join links below the DXdao description to give it more prominent view
<img width="1087" alt="Screenshot 2020-06-05 at 17 58 23" src="https://user-images.githubusercontent.com/5337809/83897674-2bacea80-a756-11ea-81ce-67267fa0b375.png">

fixes https://github.com/fMercury/dxdao-landing-page/issues/15 because we remove the footer items
